### PR TITLE
UTC-20250702: Update fonts and add library link.

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -877,7 +877,7 @@ export const Chat = memo(({stopConversationRef}: Props) => {
                                     <div
                                         className="mx-auto flex flex-col space-y-1 md:space-y-8 px-3 pt-5 md:pt-10 sm:max-w-[600px]">
                                         <div
-                                            className="text-center text-3xl font-semibold text-gray-800 dark:text-gray-100">
+                                            className="text-center text-3xl font-sans font-semibold text-gray-800 dark:text-gray-100">
                                             {filteredModels.length === 0 ? (
                                                 <div>
                                                     <Spinner size="16px" className="mx-auto"/>

--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -597,7 +597,7 @@ const onAssistantChange = (assistant: Assistant) => {
             </div>
             }
         <div style={{width: chatContainerWidth}}
-            className="chat-input absolute border-t border-b bottom-0 left-0 border-blue-500/20 bg-white py-4 dark:bg-blue-500 dark:border-white/20 md:pt-2 z-15">
+            className="chat-input absolute border-t border-b bottom-0 left-0 border-blue-500/20 bg-white py-4 dark:bg-blue-600 dark:border-white/20 md:pt-2 z-15">
             
             
             <div
@@ -903,6 +903,7 @@ const onAssistantChange = (assistant: Assistant) => {
                         />
                     )}
                 </div>
+                <div className="ai-mistakes text-sm border border-yellow-500 py-2 px-1 text-center bg-blue-700 w-full text-gray-400">AI can make mistakes. Check important info. Need help? UTC Library Research Services are <a href="https://www.utc.edu/library/help/chattutc" title="library research services" className="text-sm underline hover:no-underline text-yellow-500 ">available here</a>.</div>
             </div>
 
         </div>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -14,6 +14,7 @@ export default function Document(props: Props) {
       <Head>
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-title" content="Amplify"></meta>
+        <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;700&family=Raleway:wght@400;700&display=swap" rel="stylesheet" />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
Changes made in this PR:

- Add brand fonts to header in _document.tsx, line 17 (Windows 11 was ignoring the @import...google fonts in the globals.css)
- Add the Library box with link under the chat input field in the ChatInput.tsx files, line 906
- Add Tailwinds class "font-sans" to the Chat.tsx, line 880, for "Start a new conversation."

Double-checked chat model dropdown that uses user agent UI formatting on Windows 11 computer. Passed testing.